### PR TITLE
Consistent error messages.

### DIFF
--- a/pgdriver.go
+++ b/pgdriver.go
@@ -51,7 +51,7 @@ func resultError(res *C.PGresult) error {
 	if serr == "" {
 		return nil
 	}
-	return errors.New("result error: " + serr)
+	return errors.New(strings.TrimSpace(serr))
 }
 
 const timeFormat = "2006-01-02 15:04:05.000000-07"

--- a/pgdriver_test.go
+++ b/pgdriver_test.go
@@ -89,4 +89,17 @@ func TestPq(t *testing.T) {
 		}
 	}
 	rows.Close()
+
+	// Error messages.
+	_, err = db.Exec("INSERT INTO gopq (i32) VALUES ('error')")
+	if err == nil {
+		t.Fatal("Error not found.")
+	}
+	msg := err.Error()
+	if len(msg) == 0 {
+		t.Fatal("Empty error message")
+	}
+	if msg[len(msg)-1] == '\n' {
+		t.Fatal("Error message ends with a line break")
+	}
 }


### PR DESCRIPTION
Postgres appends line breaks to error messages. This leads to incosistent
behavior, since error messages in Go are usually one liners.
